### PR TITLE
Fix Most Unit Tests for Restart Support

### DIFF
--- a/src/opm/output/eclipse/AggregateWellData.cpp
+++ b/src/opm/output/eclipse/AggregateWellData.cpp
@@ -433,7 +433,7 @@ namespace {
             // Initial data by Statoil ASA.
             return { // 122 Items (0..121)
                 // 0     1      2      3      4      5
-                infty , infty , infty , infty ,infty , infty,    //   0..  5  ( 0)
+                infty, infty, infty, infty, infty, infty,    //   0..  5  ( 0)
                 one  , zero , zero , zero , zero , 1.0e-05f, //   6.. 11  ( 1)
                 zero , zero , infty, infty, zero , dflt ,    //  12.. 17  ( 2)
                 infty, infty, infty, infty, infty, zero ,    //  18.. 23  ( 3)
@@ -496,8 +496,6 @@ namespace {
             if (well.isProducer(sim_step)) {
                 const auto& pp = well.getProductionProperties(sim_step);
 
-                using PP = ::Opm::WellProducer::ControlModeEnum;
-
                 if (pp.OilRate != 0.0) {
                     sWell[Ix::OilRateTarget] =
                         swprop(M::liquid_surface_rate, pp.OilRate);
@@ -526,8 +524,9 @@ namespace {
                     sWell[Ix::ResVRateTarget] =
                         swprop(M::rate, pp.ResVRate);
                 }
-                //write out summary voidage production rate if target/limit is not set
 		else {
+                    // Write out summary voidage production rate if
+                    // target/limit is not set
                     sWell[Ix::ResVRateTarget] = get("WVPR");
                 }
 
@@ -538,7 +537,7 @@ namespace {
            
 		sWell[Ix::BHPTarget] = pp.BHPLimit != 0.0
                     ? swprop(M::pressure, pp.BHPLimit)
-                    : swprop(M::pressure, 14.70*::Opm::unit::psia);
+                    : swprop(M::pressure, 1.0*::Opm::unit::atm);
             }
             else if (well.isInjector(sim_step)) {
                 const auto& ip = well.getInjectionProperties(sim_step);

--- a/src/opm/output/eclipse/AggregateWellData.cpp
+++ b/src/opm/output/eclipse/AggregateWellData.cpp
@@ -548,10 +548,10 @@ namespace {
 
 		if (ip.hasInjectionControl(IP::RATE)) {
 		    if (ip.injectorType == IT::OIL) {
-			sWell[Ix::OilRateTarget] = swprop(M::gas_surface_rate, ip.surfaceInjectionRate);
+			sWell[Ix::OilRateTarget] = swprop(M::liquid_surface_rate, ip.surfaceInjectionRate);
 		    }
 		    if (ip.injectorType == IT::WATER) {
-			sWell[Ix::WatRateTarget] = swprop(M::gas_surface_rate, ip.surfaceInjectionRate);
+			sWell[Ix::WatRateTarget] = swprop(M::liquid_surface_rate, ip.surfaceInjectionRate);
 		    }
 		    if (ip.injectorType == IT::GAS) {
 			sWell[Ix::GasRateTarget] = swprop(M::gas_surface_rate, ip.surfaceInjectionRate);
@@ -559,7 +559,7 @@ namespace {
                 }
 
 		if (ip.hasInjectionControl(IP::RESV)) {
-		    sWell[Ix::ResVRateTarget] = swprop(M::gas_surface_rate, ip.reservoirInjectionRate);
+		    sWell[Ix::ResVRateTarget] = swprop(M::rate, ip.reservoirInjectionRate);
                 }		
 
                 if (ip.hasInjectionControl(IP::THP)) {

--- a/src/opm/output/eclipse/InteHEAD.cpp
+++ b/src/opm/output/eclipse/InteHEAD.cpp
@@ -596,9 +596,7 @@ Opm::RestartIO::InteHEAD::
 stepParam(const int num_solver_steps, const int sim_step)
 {
     this -> data_[NUM_SOLVER_STEPS] = num_solver_steps;
-    this -> data_[REPORT_STEP] = sim_step+1;
-
-
+    this -> data_[REPORT_STEP]      = sim_step + 1;
 
     return *this;
 }
@@ -622,18 +620,27 @@ Opm::RestartIO::InteHEAD::variousParam(const int version,
 {
     this->data_[VERSION] = version;
     this->data_[IPROG]   = iprog;
+
     // ih_049: Usage unknown, value fixed across reference cases
     this->data_[ih_049]  = 1;
+
     // ih_050: Usage unknown, value fixed across reference cases
     this->data_[ih_050]  = 1;
-    // ih_076: Usage unknown, experiments fails (zero determinant in well message) with too low numbers. 5 is highest observed across reference cases.
-    this->data_[ih_076]  = 2;
+
+    // ih_076: Usage unknown, experiments fails (zero determinant
+    //         in well message) with too low numbers.
+    //         5 is highest observed across reference cases.
+    this->data_[ih_076] = 5;
+
     // ih_101: Usage unknown, value fixed across reference cases.
-    this->data_[ih_101]  = 1;
-    // ih_103: Usage unknown, value not fixed across reference cases, experiments generate warning with 0 but not with 1.
-    this->data_[ih_103]  = 1;
+    this->data_[ih_101] = 1;
+
+    // ih_103: Usage unknown, value not fixed across reference cases,
+    //         experiments generate warning with 0 but not with 1.
+    this->data_[ih_103] = 1;
+
     // ih_200: Usage unknown, value fixed across reference cases.
-    this->data_[ih_200]  = 1;
+    this->data_[ih_200] = 1;
 
     return *this;
 }

--- a/tests/FIRST_SIM.DATA
+++ b/tests/FIRST_SIM.DATA
@@ -9,6 +9,15 @@ UNIFIN
 DIMENS
  10 10 10 /
 
+WELLDIMS
+-- Item 1: NWMAX  (Maximum number of wells in model)
+-- Item 2: NCWMAX (Maximum number of connections per well)
+-- Item 3: NGMAX  (Maximum number of groups in model--excluding FIELD)
+-- Item 4: NWGMAX (Maximum number of wells or child groups per group)
+-- NWMAX  NCWMAX  NGMAX  NWGMAX
+   6      3       1      6
+/
+
 GRID
 DXV
 10*0.25 /

--- a/tests/SUMMARY_EFF_FAC.DATA
+++ b/tests/SUMMARY_EFF_FAC.DATA
@@ -12,6 +12,15 @@ DIMENS
 REGDIMS
   10 /
 
+WELLDIMS
+-- Item 1: NWMAX  (Maximum number of wells in model)
+-- Item 2: NCWMAX (Maximum number of connections per well)
+-- Item 3: NGMAX  (Maximum number of groups in model--excluding FIELD)
+-- Item 4: NWGMAX (Maximum number of wells or child groups per group)
+-- NWMAX  NCWMAX  NGMAX  NWGMAX
+   3      2       5      2
+/
+
 OIL
 GAS
 WATER

--- a/tests/summary_deck.DATA
+++ b/tests/summary_deck.DATA
@@ -17,6 +17,15 @@ DIMENS
 REGDIMS
   10 /
 
+WELLDIMS
+-- Item 1: NWMAX  (Maximum number of wells in model)
+-- Item 2: NCWMAX (Maximum number of connections per well)
+-- Item 3: NGMAX  (Maximum number of groups in model--excluding FIELD)
+-- Item 4: NWGMAX (Maximum number of wells or child groups per group)
+-- NWMAX  NCWMAX  NGMAX  NWGMAX
+   5      2       3      2
+/
+
 OIL
 GAS
 WATER

--- a/tests/summary_deck_non_constant_porosity.DATA
+++ b/tests/summary_deck_non_constant_porosity.DATA
@@ -21,6 +21,15 @@ OIL
 GAS
 WATER
 
+WELLDIMS
+-- Item 1: NWMAX  (Maximum number of wells in model)
+-- Item 2: NCWMAX (Maximum number of connections per well)
+-- Item 3: NGMAX  (Maximum number of groups in model--excluding FIELD)
+-- Item 4: NWGMAX (Maximum number of wells or child groups per group)
+-- NWMAX  NCWMAX  NGMAX  NWGMAX
+   4      2       3      2
+/
+
 GRID
 
 DX

--- a/tests/test_AggregateWellData.cpp
+++ b/tests/test_AggregateWellData.cpp
@@ -428,15 +428,24 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data)
         const auto i0 = 0*ih.nswelz;
 
         const auto& swell = awd.getSWell();
-        BOOST_CHECK_CLOSE(swell[i0 + Ix::OilRateTarget] , 20.0e3f, 1.0e-7f);
-        BOOST_CHECK_CLOSE(swell[i0 + Ix::WatRateTarget] , 1.0e20f, 1.0e-7f);
-        BOOST_CHECK_CLOSE(swell[i0 + Ix::GasRateTarget] , 1.0e20f, 1.0e-7f);
-        BOOST_CHECK_CLOSE(swell[i0 + Ix::LiqRateTarget] , 1.0e20f, 1.0e-7f);
-        BOOST_CHECK_CLOSE(swell[i0 + Ix::ResVRateTarget], 1.0e20f, 1.0e-7f);
-        BOOST_CHECK_CLOSE(swell[i0 + Ix::THPTarget]     , 1.0e20f, 1.0e-7f);
-        BOOST_CHECK_CLOSE(swell[i0 + Ix::BHPTarget]     , 1000.0f, 1.0e-7f);
+        BOOST_CHECK_CLOSE(swell[i0 + Ix::OilRateTarget], 20.0e3f, 1.0e-7f);
 
-        BOOST_CHECK_CLOSE(swell[i0 + Ix::DatumDepth]    , 0.375f, 1.0e-7f);
+        // No WRAT limit
+        BOOST_CHECK_CLOSE(swell[i0 + Ix::WatRateTarget], 1.0e20f, 1.0e-7f);
+
+        // No GRAT limit
+        BOOST_CHECK_CLOSE(swell[i0 + Ix::GasRateTarget], 1.0e20f, 1.0e-7f);
+
+        // LRAT limit derived from ORAT + WRAT (= ORAT + 0.0)
+        BOOST_CHECK_CLOSE(swell[i0 + Ix::LiqRateTarget], 20.0e3f, 1.0e-7f);
+
+        // No direct limit, extract value from 'smry' (WVPR:OP_1)
+        BOOST_CHECK_CLOSE(swell[i0 + Ix::ResVRateTarget], 4.0f, 1.0e-7f);
+
+        // No THP limit
+        BOOST_CHECK_CLOSE(swell[i0 + Ix::THPTarget] , 1.0e20f, 1.0e-7f);
+        BOOST_CHECK_CLOSE(swell[i0 + Ix::BHPTarget] , 1000.0f, 1.0e-7f);
+        BOOST_CHECK_CLOSE(swell[i0 + Ix::DatumDepth],  0.375f, 1.0e-7f);
     }
 
     // SWEL (OP_2)

--- a/tests/test_InteHEAD.cpp
+++ b/tests/test_InteHEAD.cpp
@@ -328,8 +328,8 @@ BOOST_AUTO_TEST_CASE(Time_and_report_step)
 
     const auto& v = ih.data();
 
-    BOOST_CHECK_EQUAL(v[67], 12); // TSTEP
-    BOOST_CHECK_EQUAL(v[68],  2); // REP_STEP
+    BOOST_CHECK_EQUAL(v[67], 12);    // TSTEP
+    BOOST_CHECK_EQUAL(v[68], 2 + 1); // REP_STEP (= sim_step + 1)
 }
 
 BOOST_AUTO_TEST_CASE(Tuning_param)

--- a/tests/test_LogiHEAD.cpp
+++ b/tests/test_LogiHEAD.cpp
@@ -39,18 +39,7 @@ BOOST_AUTO_TEST_CASE(Radial_Settings_and_Init)
     BOOST_CHECK_EQUAL(v[  1], true);  //
     BOOST_CHECK_EQUAL(v[  3], false); // E300 Radial
     BOOST_CHECK_EQUAL(v[  4], true);  // E100 Radial
-    BOOST_CHECK_EQUAL(v[ 16], true); //
-    BOOST_CHECK_EQUAL(v[ 18], true); //
-    BOOST_CHECK_EQUAL(v[ 31], true); //
-    BOOST_CHECK_EQUAL(v[ 44], true); //
-    BOOST_CHECK_EQUAL(v[ 75], true); // MS Well Simulation Case
-    BOOST_CHECK_EQUAL(v[ 76], true); //
-    BOOST_CHECK_EQUAL(v[ 87], true); //
-    BOOST_CHECK_EQUAL(v[ 99], true); //
-    BOOST_CHECK_EQUAL(v[113], true); //
-    BOOST_CHECK_EQUAL(v[114], true); //
-    BOOST_CHECK_EQUAL(v[115], true); //
-    BOOST_CHECK_EQUAL(v[117], true); //
+    BOOST_CHECK_EQUAL(v[ 75], true);  // MS Well Simulation Case
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -346,6 +346,66 @@ data::Solution mkSolution( int numCells ) {
     return sol;
 }
 
+Opm::SummaryState sim_state()
+{
+    auto state = Opm::SummaryState{};
+
+    state.add("WOPR:OP_1" ,    1.0);
+    state.add("WWPR:OP_1" ,    2.0);
+    state.add("WGPR:OP_1" ,    3.0);
+    state.add("WVPR:OP_1" ,    4.0);
+    state.add("WOPT:OP_1" ,   10.0);
+    state.add("WWPT:OP_1" ,   20.0);
+    state.add("WGPT:OP_1" ,   30.0);
+    state.add("WVPT:OP_1" ,   40.0);
+    state.add("WWIR:OP_1" ,    0.0);
+    state.add("WGIR:OP_1" ,    0.0);
+    state.add("WWIT:OP_1" ,    0.0);
+    state.add("WGIT:OP_1" ,    0.0);
+    state.add("WWCT:OP_1" ,    0.625);
+    state.add("WGOR:OP_1" ,  234.5);
+    state.add("WBHP:OP_1" ,  314.15);
+    state.add("WGVIR:OP_1",    0.0);
+    state.add("WWVIR:OP_1",    0.0);
+
+    state.add("WOPR:OP_2" ,    0.0);
+    state.add("WWPR:OP_2" ,    0.0);
+    state.add("WGPR:OP_2" ,    0.0);
+    state.add("WVPR:OP_2" ,    0.0);
+    state.add("WOPT:OP_2" ,    0.0);
+    state.add("WWPT:OP_2" ,    0.0);
+    state.add("WGPT:OP_2" ,    0.0);
+    state.add("WVPT:OP_2" ,    0.0);
+    state.add("WWIR:OP_2" ,  100.0);
+    state.add("WGIR:OP_2" ,  200.0);
+    state.add("WWIT:OP_2" , 1000.0);
+    state.add("WGIT:OP_2" , 2000.0);
+    state.add("WWCT:OP_2" ,    0.0);
+    state.add("WGOR:OP_2" ,    0.0);
+    state.add("WBHP:OP_2" ,  400.6);
+    state.add("WGVIR:OP_2", 1234.0);
+    state.add("WWVIR:OP_2", 4321.0);
+
+    state.add("WOPR:OP_3" ,   11.0);
+    state.add("WWPR:OP_3" ,   12.0);
+    state.add("WGPR:OP_3" ,   13.0);
+    state.add("WVPR:OP_3" ,   14.0);
+    state.add("WOPT:OP_3" ,  110.0);
+    state.add("WWPT:OP_3" ,  120.0);
+    state.add("WGPT:OP_3" ,  130.0);
+    state.add("WVPT:OP_3" ,  140.0);
+    state.add("WWIR:OP_3" ,    0.0);
+    state.add("WGIR:OP_3" ,    0.0);
+    state.add("WWIT:OP_3" ,    0.0);
+    state.add("WGIT:OP_3" ,    0.0);
+    state.add("WWCT:OP_3" ,    0.0625);
+    state.add("WGOR:OP_3" , 1234.5);
+    state.add("WBHP:OP_3" ,  314.15);
+    state.add("WGVIR:OP_3",    0.0);
+    state.add("WWVIR:OP_3",   43.21);
+
+    return state;
+}
 
 RestartValue first_sim(const EclipseState& es, EclipseIO& eclWriter, bool write_double) {
     const auto& grid = es.getInputGrid();
@@ -527,15 +587,17 @@ BOOST_AUTO_TEST_CASE(ExtraData_content) {
         const auto& units = setup.es.getUnits();
         {
             RestartValue restart_value(cells, wells);
-	    Opm::SummaryState sumState;
+            const auto sumState = sim_state();
+
             restart_value.addExtra("EXTRA", UnitSystem::measure::pressure, {10,1,2,3});
+
             RestartIO::save("FILE.UNRST", 1 ,
                             100,
                             restart_value,
                             setup.es,
                             setup.grid,
                             setup.schedule,
-			    sumState);
+                            sumState);
 
             {
                 ecl_file_type * f = ecl_file_open( "FILE.UNRST" , 0 );
@@ -545,8 +607,8 @@ BOOST_AUTO_TEST_CASE(ExtraData_content) {
                     BOOST_CHECK_EQUAL( ecl_kw_get_header( ex) , "EXTRA" );
                     BOOST_CHECK_EQUAL(  4 , ecl_kw_get_size( ex ));
 
-                    BOOST_CHECK_CLOSE( 10 ,                                                units.to_si( UnitSystem::measure::pressure, ecl_kw_iget_double( ex, 0 )), 0.00001);
-                    BOOST_CHECK_CLOSE( units.from_si( UnitSystem::measure::pressure, 3)  , ecl_kw_iget_double( ex, 3 ),                                              0.00001);
+                    BOOST_CHECK_CLOSE( 10 , units.to_si( UnitSystem::measure::pressure, ecl_kw_iget_double( ex, 0 )), 0.00001);
+                    BOOST_CHECK_CLOSE( units.from_si( UnitSystem::measure::pressure, 3), ecl_kw_iget_double( ex, 3 ), 0.00001);
                 }
                 ecl_file_close( f );
             }
@@ -554,11 +616,17 @@ BOOST_AUTO_TEST_CASE(ExtraData_content) {
             BOOST_CHECK_THROW( RestartIO::load( "FILE.UNRST" , 1 , {}, setup.es, setup.grid , setup.schedule,
                                                 {{"NOT-THIS", UnitSystem::measure::identity, true}}) , std::runtime_error );
             {
-              const auto rst_value = RestartIO::load( "FILE.UNRST" , 1 , { RestartKey("SWAT", UnitSystem::measure::identity),
-                                                                           RestartKey("NO", UnitSystem::measure::identity, false)},
-                setup.es, setup.grid , setup.schedule,
-                {{"EXTRA", UnitSystem::measure::pressure, true},
-                 {"EXTRA2", UnitSystem::measure::identity, false}});
+                const auto rst_value = RestartIO::load(
+                    "FILE.UNRST" , 1 ,
+                    /* solution_keys = */ {
+                        RestartKey("SWAT", UnitSystem::measure::identity),
+                        RestartKey("NO"  , UnitSystem::measure::identity, false)
+                    },
+                    setup.es, setup.grid , setup.schedule,
+                    /* extra_keys = */ {
+                        {"EXTRA" , UnitSystem::measure::pressure, true}  ,
+                        {"EXTRA2", UnitSystem::measure::identity, false}
+                    });
 
                 BOOST_CHECK(!rst_value.hasExtra("EXTRA2"));
                 BOOST_CHECK( rst_value.hasExtra("EXTRA"));
@@ -601,7 +669,8 @@ BOOST_AUTO_TEST_CASE(STORE_THPRES) {
             */
 
             restart_value.addExtra("THRESHPR", UnitSystem::measure::pressure, {0,1});
-	    Opm::SummaryState sumState;
+            const auto sumState = sim_state();
+
             /* THPRES data has wrong size in extra container. */
             BOOST_CHECK_THROW( RestartIO::save("FILE.UNRST", 1 ,
                                                100,
@@ -609,7 +678,7 @@ BOOST_AUTO_TEST_CASE(STORE_THPRES) {
                                                setup.es,
                                                setup.grid,
                                                setup.schedule,
-					       sumState), std::runtime_error);
+                                               sumState), std::runtime_error);
 
             int num_regions = setup.es.getTableManager().getEqldims().getNumEquilRegions();
             std::vector<double>  thpres(num_regions * num_regions, 78);

--- a/tests/testblackoilstate3.DATA
+++ b/tests/testblackoilstate3.DATA
@@ -17,6 +17,15 @@ METRIC
 DIMENS
     10  10   10   /
 
+WELLDIMS
+-- Item 1: NWMAX  (Maximum number of wells in model)
+-- Item 2: NCWMAX (Maximum number of connections per well)
+-- Item 3: NGMAX  (Maximum number of groups in model--excluding FIELD)
+-- Item 4: NWGMAX (Maximum number of wells or child groups per group)
+-- NWMAX  NCWMAX  NGMAX  NWGMAX
+   9      10      2      6
+/
+
 GRID
 DXV 
 10*10 /


### PR DESCRIPTION
This change-set restores most of the unit tests for Restart PR (OPM/opm-common#454).  In particular, we ensure that we always have WELDIMS in the simulation decks (needed to allocate appropriate output vectors for well-related quantities).  We also correct the units of measurement for injection rates (need to distinguish liquid rates from gas rates at surface conditions), and correct a few comparison values in the "InteHEAD", "LogiHEAD", and "AggregateWellData" unit tests.