### PR TITLE
Remove struct udqParam use existing class UDQParams

### DIFF
--- a/opm/output/eclipse/DoubHEAD.hpp
+++ b/opm/output/eclipse/DoubHEAD.hpp
@@ -40,12 +40,6 @@ namespace Opm { namespace RestartIO {
             std::chrono::duration<double, std::chrono::seconds::period> elapsed;
         };
         
-        struct udqParam {
-            double udq_param_2;
-            double udq_param_3;
-            double udq_param_4;
-        };
-
         DoubHEAD();
 
         ~DoubHEAD() = default;
@@ -66,7 +60,7 @@ namespace Opm { namespace RestartIO {
                         const std::size_t lookup_step,
 			const double      cnvT);
 	
-	DoubHEAD& udq_param(const udqParam& udqPar);
+	DoubHEAD& udq_param(const UDQParams& udqPar);
 
         const std::vector<double>& data() const
         {

--- a/src/opm/output/eclipse/CreateDoubHead.cpp
+++ b/src/opm/output/eclipse/CreateDoubHead.cpp
@@ -43,17 +43,6 @@ namespace {
                 double, std::chrono::seconds::period>{ elapsed },
         };
     }
-    
-    Opm::RestartIO::DoubHEAD::udqParam 
-    getUDQParam(const ::Opm::Runspec rspec)
-    {
-        const auto udqPar = rspec.udqParams();
-        return {
-            udqPar.range(),
-            udqPar.undefinedValue(),
-            udqPar.cmpEpsilon()
-        };
-    }
 
     double getTimeConv(const ::Opm::UnitSystem& us)
     {

--- a/src/opm/output/eclipse/DoubHEAD.cpp
+++ b/src/opm/output/eclipse/DoubHEAD.cpp
@@ -622,11 +622,11 @@ Opm::RestartIO::DoubHEAD::drsdt(const Schedule&   sched,
 }
 
 Opm::RestartIO::DoubHEAD&
-Opm::RestartIO::DoubHEAD::udq_param(const udqParam& udqPar)
+Opm::RestartIO::DoubHEAD::udq_param(const UDQParams& udqPar)
 {
-    this->data_[UdqPar_2] = udqPar.udq_param_2;
-    this->data_[UdqPar_3] = udqPar.udq_param_3;
-    this->data_[UdqPar_4] = udqPar.udq_param_4;
+    this->data_[UdqPar_2] = udqPar.range();
+    this->data_[UdqPar_3] = udqPar.undefinedValue();
+    this->data_[UdqPar_4] = udqPar.cmpEpsilon();
 
     return *this;
 }


### PR DESCRIPTION
Minor simplification - mostly for unknown navigators.